### PR TITLE
Decode json error response

### DIFF
--- a/src/Multivers.php
+++ b/src/Multivers.php
@@ -129,7 +129,7 @@ class Multivers
             'json' =>  ($method != 'GET' ? $parameters : null),
         ]);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
-            dd($e->getResponse()->getBody()->getContents());
+            dd(json_decode($e->getResponse()->getBody()->getContents()));
         }
 
         // JSON decode.


### PR DESCRIPTION
It is a huge improvement when debugging to see the errors formatted as an array instead of one (large) json blob.